### PR TITLE
Add AutoFactionChat Plugin and update description for AdminAbilitiesTracker

### DIFF
--- a/Plugins/AdminAbilitiesTracker.xml
+++ b/Plugins/AdminAbilitiesTracker.xml
@@ -5,16 +5,16 @@
   <Author>Pas2704</Author>
   <Tooltip>Lets you keep track of admin abilities being used on the server.</Tooltip>
   <Description>Lets you keep track of admin abilities being used on the server.
-  More specifically, it can keep track of players using:
-	Invulnerable,
-	ShowPlayers,
-	UseTerminals,
-	Untargetable, 
-	KeepOriginalOwnershipOnPaste,
-	IgnoreSafezones,
-	IgnorePCU
-  It also shows what abilities are currently in use in your shift + f11 menu.
-  Changes are tracked with local chat messages, but will only work in multiplayer games where you are not the host.
-  These chat messages can be disabled in the config if you choose.</Description>
+More specifically, it can keep track of players using:
+Invulnerable,
+ShowPlayers,
+UseTerminals,
+Untargetable, 
+KeepOriginalOwnershipOnPaste,
+IgnoreSafezones,
+IgnorePCU
+It also shows what abilities are currently in use in your shift + f11 menu.
+Changes are tracked with local chat messages, but will only work in multiplayer games where you are not the host.
+These chat messages can be disabled in the config if you choose.</Description>
   <Commit>fb092dc8a5e45791db5f5722979a79e26854c2a7</Commit>
 </PluginData>

--- a/Plugins/AutoFactionChat.xml
+++ b/Plugins/AutoFactionChat.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>Pas2704/AutoFactionChat</Id>
+  <FriendlyName>AutoFactionChat</FriendlyName>
+  <Author>Pas2704</Author>
+  <Tooltip>Start in faction channel instead of global</Tooltip>
+  <Description>This plugin forces your chat to start in the faction channel instead of the global channel.
+This will happen even if you are not in a faction. 
+To switch back to the global channel, use "/g".</Description>
+  <Commit>b6a5a5c174e2880c4b1b0388c23d8ce13a6481d1</Commit>
+</PluginData>


### PR DESCRIPTION
AutoFactionChat is a QoL plugin that will make the default channel the faction channel instead of the global channel.
I accidentally left some weird spaces in the description for my other plugin, so I removed those.