### PR TITLE
Update Seamless maintainer and release 1.5.0

### DIFF
--- a/Plugins/SeamlessClient.xml
+++ b/Plugins/SeamlessClient.xml
@@ -19,5 +19,5 @@
   <Description>This plugin allows seamless transfers between Nexus enabled servers. Some mods or plugins may not play nice with switching between servers. Be cautious when using!</Description>
   
   <!-- The commit id. You can find this in the commits list: https://github.com/austinvaness/ToolSwitcherPlugin/commits/main -->
-  <Commit>32ae6569a8c20639c6337e0974429e5e2af1f6e8</Commit>
+  <Commit>b41598d025c818102656a3c6b6c1ef6896811d22</Commit>
 </PluginData>

--- a/Plugins/SeamlessClient.xml
+++ b/Plugins/SeamlessClient.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
   <!-- Place your github repository name here. One repository can only store one plugin. This one is from https://github.com/austinvaness/ToolSwitcherPlugin -->
-  <Id>Casimir255/SeamlessClientPlugin</Id>
+  <Id>vxlgames/SeamlessClientPlugin</Id>
   
   <!-- Optional tag that specifies the group this plugin belongs to. Only one plugin from a given group can be enabled. -->
   <GroupId>NexusSeamless</GroupId>
@@ -10,7 +10,7 @@
   <FriendlyName>NexusSeamlessClient</FriendlyName>
   
   <!-- The author name that you want to appear in the list. -->
-  <Author>Casimir</Author>
+  <Author>Voxel Games</Author>
   
   <!-- Optional tag that adds a tooltip to the plugin in-game. -->
   <Tooltip>Allows transferring between Nexus enabled servers seamlessly</Tooltip>

--- a/Plugins/SeamlessClient.xml
+++ b/Plugins/SeamlessClient.xml
@@ -19,5 +19,5 @@
   <Description>This plugin allows seamless transfers between Nexus enabled servers. Some mods or plugins may not play nice with switching between servers. Be cautious when using!</Description>
   
   <!-- The commit id. You can find this in the commits list: https://github.com/austinvaness/ToolSwitcherPlugin/commits/main -->
-  <Commit>b41598d025c818102656a3c6b6c1ef6896811d22</Commit>
+  <Commit>4448143d6f29243c294ab5e46f4843cfb6ceba23</Commit>
 </PluginData>


### PR DESCRIPTION
This updates the seamless client to reference the new maintainers (can verify via going to https://github.com/Casimir255/SeamlessClientPlugin) and home and releases the 1.5.0 update.

Changes in 1.5.0 mostly code clean-up as well as some performance improvements to the client.