### PR TITLE
Add FpsUnlocker Plugin to Plugin Loader (add FpsUnlocker.xml)

### DIFF
--- a/Plugins/FpsUnlocker.xml
+++ b/Plugins/FpsUnlocker.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>ritaelyn/FPSUnlocker</Id>
+  <GroupId>FpsUnlocker</GroupId>
+  <FriendlyName>Fps Unlocker</FriendlyName>
+  <Author>Ritaelyn</Author>
+  <Commit>8b7448b34eb4b68be20b3e540eedb056abb6666e</Commit>
+  <SourceDirectories>
+    <Directory>Shared</Directory>
+    <Directory>ClientPlugin</Directory>
+  </SourceDirectories>
+  <Tooltip>Sets Space Engineer's Framerate Cap to 500 fps</Tooltip>
+  <Description>
+	  This plugin sets Space Engineer's Framerate Cap to 500 fps. Edit the config if you desire to have a different cap.
+  </Description>
+</PluginData>


### PR DESCRIPTION
Hi! :) I created a new plugin that lets players change the framerate cap on Space Engineers. The default framerate cap is 120 fps. This plugin lets one adjust the framerate cap to any value they desire in the config with a slider from 60fps to 500 fps. A player could set it to match their monitor rate  such as 144 fps, 165fps, 240fps, etc. My plugin sets the cap to 500 by default. 

I also notice my plugin helps greatly with performance for the Camera LCD Mod when it's set to such a high framerate like 500 fps. I hope everyone finds the plugin useful! 

https://github.com/ritaelyn/FPSUnlocker
