### PR TITLE
Add Missing Search Boxes Plugin

### DIFF
--- a/Plugins/AddMissingSearchBoxes.xml
+++ b/Plugins/AddMissingSearchBoxes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>WesternGamer/AddMissingSearchBoxes</Id>
+  <FriendlyName>Add Missing Search Boxes</FriendlyName>
+  <Author>WesternGamer</Author>
+  <Tooltip>Adds searchboxes to parts of the SE ui that should have one.</Tooltip>
+  <Description>This plugin currently adds a searchbox to the factions list so you can find factions much faster now! It also allows you to search chat history more easily with the addition of the searchbox in the comms section!</Description>
+  <Commit>94b11768f4de38661cfa45a1fb20deb53ed80fe4</Commit>
+</PluginData>


### PR DESCRIPTION
This plugin currently adds a search box to the factions menu and comms menu in the terminal.