### PR TITLE
Revise Flight Vector and add Status Report

### DIFF
--- a/Plugins/Mods/Flight Vector.xml
+++ b/Plugins/Mods/Flight Vector.xml
@@ -4,16 +4,17 @@
   <FriendlyName>Flight Vector</FriendlyName>
   <Author>BDCarrillo</Author>
   <Tooltip></Tooltip>
-  <Description>Overview
-When seated in a cockpit, this mod draws lines to depict the prograde, retrograde, and gravity vector for your current grid. Note these lines are a fixed length, and only indicate direction.
+  <Description>
+When seated in a cockpit, this mod draws aids to depict the prograde, retrograde, and gravity vector for your current grid. Note these lines are a fixed length, and only indicate direction.
 
 B(lue)ow, R(ed)everse, G(reen)ravity
 
 Runs client-side only.
 
-You can cycle the line overlays by typing "/vector" in chat
+You can cycle the line overlays by typing "/vector lines" or "/vector symbols" in chat.  Defaults and color configurations are available, please see the mod page for details https://steamcommunity.com/sharedfiles/filedetails/?id=2950011596
 
 Credits
 -DirectedEnergy for the idea
--Jerrai for the clever mnemonic</Description>
+-Jerrai for the clever mnemonic
+</Description>
 </PluginData>

--- a/Plugins/Mods/Status Report.xml
+++ b/Plugins/Mods/Status Report.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ModPlugin">
+  <Id>2950431210</Id>
+  <FriendlyName>Status Report</FriendlyName>
+  <Author>BDCarrillo</Author>
+  <Tooltip></Tooltip>
+  <Description>Ever wanted a concise report of things happening on your ship? Well with simple chat inputs you can inundate yourself in data!
+
+/report
+Shows a list of commands in the chat box
+
+/report inventory
+Displays all components, ores, ingots, and ammo on board
+
+/report damage
+Shows damaged functional (not armor) blocks
+
+/report twr
+Displays thrust-to-weight ratio and max lift capability for hydrogen thrusters
+
+/report cargo
+Displays cargo capacity and fill level of your ship
+
+/report power
+Displays a count and status of functional power producing blocks
+
+Runs client-side only.
+Please see the mod page for details/updates/feedback https://steamcommunity.com/sharedfiles/filedetails/?id=2950431210
+
+</Description>
+</PluginData>


### PR DESCRIPTION
-Minor fixes to description of Flight Vector, including link to Steam Workshop
-Add Status Report, client-side only mod that gathers information about the current grid/inventory/systems