### PR TITLE
Update github.xml

### DIFF
--- a/Plugins/SEWorldGenPlugin_v2/github.xml
+++ b/Plugins/SEWorldGenPlugin_v2/github.xml
@@ -4,5 +4,5 @@
   <FriendlyName>SEWorldGenPlugin V2</FriendlyName>
   <Author>thorwin99</Author>
   <GroupId>SEWorldGenPlugin</GroupId>
-  <Commit>5212570d27531355bfee8f6048017221bce8ac2a</Commit>
+  <Commit>1690fd9c0ec20349b7f2cdfb681869ecbf92b697</Commit>
 </PluginData>


### PR DESCRIPTION
Updated SEWG to latest version, which fixes a crash caused by the plugin.
For changelog, see [here](https://github.com/thorwin99/SEWorldGenPlugin/releases/tag/v2.1.6.14)