### PR TITLE
GPS Marker Scaling Bug Fix

### DIFF
--- a/Plugins/GPSMarkerScaling.xml
+++ b/Plugins/GPSMarkerScaling.xml
@@ -6,5 +6,5 @@
   <Author>WesternGamer</Author>
   <Tooltip>Allows GPS Icon Scale to be changed.</Tooltip>
   <Description>Allows GPS Icon Scale to be changed with Alt + Shift + Scrollwheel.</Description>
-  <Commit>2ec5178291337f9a9277bb101596ea9679d0795b</Commit>
+  <Commit>7e1a99bd0f00df51eebbe2a4ea7fea16f753fe7c</Commit>
 </PluginData>


### PR DESCRIPTION
Fixed an issue where the plugin would not load if the folder that normally contains the config does not exist.

https://github.com/WesternGamer/ProperGPSMarkerScaling/commit/aa4d67d56f2427728475d6e8cc82ca724c128aff