### PR TITLE
GPS Marker Scaling Bug Fix

### DIFF
--- a/Plugins/GPSMarkerScaling.xml
+++ b/Plugins/GPSMarkerScaling.xml
@@ -6,5 +6,5 @@
   <Author>WesternGamer</Author>
   <Tooltip>Allows GPS Icon Scale to be changed.</Tooltip>
   <Description>Allows GPS Icon Scale to be changed with Alt + Shift + Scrollwheel.</Description>
-  <Commit>8147d158976031640996a90d38d9a89e4813a2b6</Commit>
+  <Commit>1c3bc41008310538c366f82465e6f01f7017716f</Commit>
 </PluginData>

--- a/Plugins/GPSMarkerScaling.xml
+++ b/Plugins/GPSMarkerScaling.xml
@@ -6,5 +6,5 @@
   <Author>WesternGamer</Author>
   <Tooltip>Allows GPS Icon Scale to be changed.</Tooltip>
   <Description>Allows GPS Icon Scale to be changed with Alt + Shift + Scrollwheel.</Description>
-  <Commit>7e1a99bd0f00df51eebbe2a4ea7fea16f753fe7c</Commit>
+  <Commit>8147d158976031640996a90d38d9a89e4813a2b6</Commit>
 </PluginData>


### PR DESCRIPTION
Fixed scale defaulting to 1. 

https://github.com/WesternGamer/ProperGPSMarkerScaling/commit/8147d158976031640996a90d38d9a89e4813a2b6
https://github.com/WesternGamer/ProperGPSMarkerScaling/commit/1c3bc41008310538c366f82465e6f01f7017716f