### PR TITLE
Add Build Vision and Rich HUD master as mod plugins

### DIFF
--- a/Plugins/Mods/BuildVision.xml
+++ b/Plugins/Mods/BuildVision.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ModPlugin">
+  <Id>1697184408</Id>
+  <FriendlyName>Build Vision</FriendlyName>
+  <Author>DarkHelmet</Author>
+  <Tooltip>This is a quick access context menu designed to supplement the game's terminal. *Requires Rich HUD Master.*</Tooltip>
+  <DependencyIds>
+    <Id>1965654081</Id>
+  </DependencyIds>
+</PluginData>

--- a/Plugins/Mods/RichHudMaster.xml
+++ b/Plugins/Mods/RichHudMaster.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ModPlugin">
+  <Id>1965654081</Id>
+  <FriendlyName>Rich HUD Master</FriendlyName>
+  <Author>DarkHelmet</Author>
+  <Tooltip>UI Framework dependency required by some mods.</Tooltip>
+</PluginData>


### PR DESCRIPTION
I've updated Build Vision to disable features depending on server-side code if PLUGIN_LOADER is defined. The RHM dependency was already purely client-side and will work as-is.