### PR TITLE
plugins: add TimeoutFix

### DIFF
--- a/Plugins/TimeoutFix.xml
+++ b/Plugins/TimeoutFix.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>StalkR/Space-Engineers-Timeout-Fix</Id>
+  <GroupId>TimeoutFix</GroupId>
+  <FriendlyName>Timeout Fix</FriendlyName>
+  <Author>rexxar</Author>
+  <Tooltip>Fix the "server is not responding" error.</Tooltip>
+  <Commit>5b6345f77512277334abd883363aeb422f5f8a62</Commit>
+  <Description>This plugin fixes the "server is not responding" error.</Description>
+</PluginData>


### PR DESCRIPTION
The TimeoutFix plugin was written originally in 2020 by Space Engineers community member _rexxar_, now retired.

Until now, the TimeoutFix plugin was distributed among the Space Engineers community in binary form (dll).

Instead, now that we have PluginLoader, I propose to distribute it via the plugin hub, with reviewable source taken from the decompilation of the original dll. No other modifications were made.

I'm hoping this will put an end to the practice of sharing the dll and associated risks, in favor of the more trustworthy PluginLoader.

For more information about what the plugin does, see the [readme](https://github.com/StalkR/Space-Engineers-Timeout-Fix), in particular the [reddit post](https://www.reddit.com/r/spaceengineers/comments/f7ul3s/fix_for_server_is_not_responding_error/) by _rexxar_, and [Keen bug report](https://support.keenswh.com/spaceengineers/pc/topic/server-not-responding-many-unable-to-join-servers).