### PR TITLE
RDR2 Death Screen 1.0.1

### DIFF
--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -5,5 +5,5 @@
   <FriendlyName>RDR2 Death Screen</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
-  <Commit>e67bd9e35921325333b609e053f7722edc5179a4</Commit>
+  <Commit>45c2ed3ce0b0bbdbf188390ac500ae56cd7fa67a</Commit>
 </PluginData>

--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -5,5 +5,5 @@
   <FriendlyName>RDR2 Death Screen</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
-  <Commit>45c2ed3ce0b0bbdbf188390ac500ae56cd7fa67a</Commit>
+  <Commit>eaa917a023f5cb89a7161ac5a63db9ce861600a1</Commit>
 </PluginData>


### PR DESCRIPTION
https://github.com/WesternGamer/RDR2DeathScreen/commit/45c2ed3ce0b0bbdbf188390ac500ae56cd7fa67a
https://github.com/WesternGamer/RDR2DeathScreen/commit/eaa917a023f5cb89a7161ac5a63db9ce861600a1

- Project refactored.
- MyGuiScreenGamePlay.DisableInput will behave normally if the death screen is not present. This is to support other plugins looking to use MyGuiScreenGamePlay.DisableInput, but without disabling unhandled inputs.