### PR TITLE
Add Assembler Sorting Plugin

### DIFF
--- a/Plugins/AssemblerSorting.xml
+++ b/Plugins/AssemblerSorting.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>theit8514/AssemblerSortPlugin</Id>
+  <GroupId>theit8514/AssemblerSortPlugin</GroupId>
+  <FriendlyName>Assembler Sorting</FriendlyName>
+  <Author>theit8514</Author>
+  <Commit>c78d31f73b4e70a0189332326ce897c204629e39</Commit>
+  <SourceDirectories>
+    <Directory>ClientPlugin</Directory>
+  </SourceDirectories>
+  <Tooltip>Sort Assemblers the best way</Tooltip>
+  <Description>Sorts the assemblers on the Production GUI.
+  
+Sort order:
+  1. The current selected block (if it is an Assembler) which is default selected.
+  2. Incomplete blocks are sorted to the bottom.
+  3. Then the assemblers are sorted by display name.
+  </Description>
+</PluginData>


### PR DESCRIPTION
Sorts assemblers by selected block first, then completed blocks, then by display name.