### PR TITLE
Mod: Rationalised Build Menu

### DIFF
--- a/Plugins/Mods/RationalisedBuildMenu.xml
+++ b/Plugins/Mods/RationalisedBuildMenu.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ModPlugin">
+  <!-- Place the steam id of your workshop item here. -->
+  <Id>3354754263</Id>
+
+  <!-- The name of your plugin that will appear in the list. -->
+  <FriendlyName>Rationalised Build Menu</FriendlyName>
+
+  <!-- The author name that you want to appear in the list. -->
+  <Author>wellington6012</Author>
+  
+  <!-- Optional tag that adds a tooltip to the plugin in-game. -->
+  <Tooltip>Better block groups in the G Menu</Tooltip>
+  
+  <!-- Optional tag that adds a plugin description. If omitted, this will be the same as the Tooltip. 1000 characters max. -->
+  <Description>I built this mod to be able to fit more blocks in the limited toolbar slots and have the block groups make more sense. Please see the mod's Workshop page (More Info) for the detailed description.</Description>
+  
+  <!-- Optional tag that specifies whether the plugin is hidden. Hidden plugins only appear when they are enabled or searched for in the search box. -->
+  <Hidden>false</Hidden>
+  
+  <!-- Optional tag that specifies what dependencies this mod has. Dependencies will be automatically enabled when this mod is enabled. -->
+  <DependencyIds />
+</PluginData>


### PR DESCRIPTION
The only thing this mod does is adding `BlockVariantGroups_Rationalised.sbc` to set up better block groups than Keen did in the Contact update. This mod has no code at all and affects only the blocks groups in the G menu and the player's character toolbar.