### PR TITLE
Adding the Flight HUD mod

### DIFF
--- a/Plugins/Mods/Flight HUD.xml
+++ b/Plugins/Mods/Flight HUD.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ModPlugin">
+<Id>3445281509</Id>
+
+<FriendlyName>Flight HUD (Mod)</FriendlyName>
+
+<Author>Brillcrafter</Author>
+
+<Tooltip>Displays your Azimuth, Elevation and Roll.</Tooltip>
+
+<Description>This is a Mod that will display your current Azimuth, Elevation and Roll, with an Artificial Horizon and scrolling displays to help you keep oriented. REQUIRES TEXTHUDAPI TO WORK </Description>
+
+<Hidden>false</Hidden>
+
+<DependencyIds>
+    <Id>758597413</Id>
+  </DependencyIds>
+</PluginData>


### PR DESCRIPTION
This should add the [Flight HUD mod](https://steamcommunity.com/sharedfiles/filedetails/?id=3445281509) to the pluginloader, if I have goofed up the XML please lmk its my first time doing stuff like this lol.
This mod displays your current azimuth (heading), elevation and your roll (via an artificial horizon). This was crafted for use on the sigma draconis expanse server, but I can see it having use on other servers.
This is also the first mod I have published to the workshop so again I may have goofed things up on that side as well lol.
