### PR TITLE
Update Add Missing Search Boxes

### DIFF
--- a/Plugins/AddMissingSearchBoxes.xml
+++ b/Plugins/AddMissingSearchBoxes.xml
@@ -5,5 +5,5 @@
   <Author>WesternGamer</Author>
   <Tooltip>Adds searchboxes to parts of the SE ui that should have one.</Tooltip>
   <Description>Adds searchboxes to parts of the SE ui that should have one.</Description>
-  <Commit>69d01260643fcd7901bf41a52917c1f119cf6de8</Commit>
+  <Commit>61b858a68f5ed31df13ce40b950047e9c3f5d57d</Commit>
 </PluginData>


### PR DESCRIPTION
Updated Add Missing Search Boxes to remove the patched in search box in the spawn menu, as it has been added as a vanilla feature in 1.206.

https://github.com/WesternGamer/AddMissingSearchBoxes/commit/b920d59d308abd5f55f7d25a4071c585f1a8d8e8
https://github.com/WesternGamer/AddMissingSearchBoxes/commit/d1b19a04f4649e308e553196bd64758f2e431638
https://github.com/WesternGamer/AddMissingSearchBoxes/commit/61b858a68f5ed31df13ce40b950047e9c3f5d57d