### PR TITLE
Revert "Updated Dudes Plugins"

### DIFF
--- a/Plugins/AutoRemoveStone.xml
+++ b/Plugins/AutoRemoveStone.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin"> 
-  <Id>dj8552/AutoRemoveStone</Id>
+  <Id>Allen-Wrench/AutoRemoveStone</Id>
   <FriendlyName>Automatic Stone Removal</FriendlyName>
   <Author>dude</Author>
   <Tooltip>Automatically removes stone and/or ice from your ship.</Tooltip>
   <Description>When enabled, stone will automatically be deleted from your ships cargo. Enable by either using the button at the bottom of a ship drills terminal page, or by adding the toggle action to your toolbar. Function will stay on until you toggle it back off, or release control of your ship. *NEW* Added ice as another material to remove.
   </Description>
-  <Commit>636e4b0c06ffeb10eebfced1a763edd6b9ecbe59</Commit> 
+  <Commit>ccf9f82b77c32a6f75816120202bab2ebcf6ecc1</Commit> 
 </PluginData>

--- a/Plugins/JumpSelector.xml
+++ b/Plugins/JumpSelector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
-  <Id>dj8552/JumpSelector</Id>
+  <Id>Allen-Wrench/JumpSelector</Id>
   <GroupId>JumpSelector</GroupId>
   <FriendlyName>Jump Selector</FriendlyName>
   <Author>dude</Author>
@@ -13,6 +13,6 @@
   Removes the field of view changes from the jump effect animation.
   *NEW* Added support for the custom turret controller.
   </Description>
-  <Commit>49a3518cb10382df7a20ab6d593690074f055784</Commit>
+  <Commit>1536931baa67a71f9df6824b406ab15b3fd71681</Commit>
   <Hidden>false</Hidden>
 </PluginData>


### PR DESCRIPTION
Reverts sepluginloader/PluginHub#370

We cannot change the GitHub path, because it is used as the "key" for subscriptions and stats. Users would be kicked out.