### PR TITLE
v3.0.0.9 Update

### DIFF
--- a/Plugins/SeamlessClient.xml
+++ b/Plugins/SeamlessClient.xml
@@ -16,5 +16,5 @@
   <Description>This plugin allows seamless transfers between Nexus enabled servers. Some mods or plugins may not play nice with switching between servers. Be cautious when using!</Description>
   
   <!-- The commit id. You can find this in the commits list: https://github.com/austinvaness/ToolSwitcherPlugin/commits/main -->
-  <Commit>f7309f5703e242a128781f1d86c49759b903016a</Commit>
+  <Commit>f60442e82e557cb608a1ba51badcc2a69ab6366d</Commit>
 </PluginData>


### PR DESCRIPTION
Another possible fix for: 

Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Sandbox.Game.EntityComponents.MyTargetLockingComponent.Update()
   at Sandbox.Game.Entities.Character.MyCharacter.UpdateAfterSimulation10()
   at Sandbox.Game.Entities.MyParallelEntityUpdateOrchestrator.UpdateAfterSimulation10()

The Parrallel Orchestrator is now being cleared on unload to remove any lingering entity updates that are non-existent. Possible cause was entities were removed but queued updates were still in the middle of updating. Fixes the above issue as well as other one off crashes from random entity crashes.
 